### PR TITLE
static import cannot be resolved in SubMenusMatching

### DIFF
--- a/org.springsource.ide.eclipse.commons.frameworks.test.util/META-INF/MANIFEST.MF
+++ b/org.springsource.ide.eclipse.commons.frameworks.test.util/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Require-Bundle: org.eclipse.swtbot.go;resolution:=optional,
  org.springsource.ide.eclipse.commons.tests.util,
  org.eclipse.debug.core
 Export-Package: org.springsource.ide.eclipse.commons.frameworks.test.util
+Import-Package: org.hamcrest;version="1.1.0"


### PR DESCRIPTION
Maybe it's just me, but after cloning the repo I can see an import error in org.springsource.ide.eclipse.commons.frameworks.test.util.SubMenusMatching. Adding org.hamcrest via Import-Package fixes it.
