### PR TITLE
URL Cleanup

### DIFF
--- a/org.springsource.ide.eclipse.commons.browser/pom.xml
+++ b/org.springsource.ide.eclipse.commons.browser/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.configurator/pom.xml
+++ b/org.springsource.ide.eclipse.commons.configurator/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.content.core/pom.xml
+++ b/org.springsource.ide.eclipse.commons.content.core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.core/pom.xml
+++ b/org.springsource.ide.eclipse.commons.core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.frameworks.core/pom.xml
+++ b/org.springsource.ide.eclipse.commons.frameworks.core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.frameworks.test.util/pom.xml
+++ b/org.springsource.ide.eclipse.commons.frameworks.test.util/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.frameworks.ui/pom.xml
+++ b/org.springsource.ide.eclipse.commons.frameworks.ui/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.gettingstarted/pom.xml
+++ b/org.springsource.ide.eclipse.commons.gettingstarted/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.jdk_tools/pom.xml
+++ b/org.springsource.ide.eclipse.commons.jdk_tools/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.livexp/pom.xml
+++ b/org.springsource.ide.eclipse.commons.livexp/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.quicksearch.feature/pom.xml
+++ b/org.springsource.ide.eclipse.commons.quicksearch.feature/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.quicksearch.test/pom.xml
+++ b/org.springsource.ide.eclipse.commons.quicksearch.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.quicksearch/pom.xml
+++ b/org.springsource.ide.eclipse.commons.quicksearch/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.site-e44/pom.xml
+++ b/org.springsource.ide.eclipse.commons.site-e44/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.site/pom.xml
+++ b/org.springsource.ide.eclipse.commons.site/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.test-feature/pom.xml
+++ b/org.springsource.ide.eclipse.commons.test-feature/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.tests.util/pom.xml
+++ b/org.springsource.ide.eclipse.commons.tests.util/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.tests/pom.xml
+++ b/org.springsource.ide.eclipse.commons.tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.commons.ui/pom.xml
+++ b/org.springsource.ide.eclipse.commons.ui/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.dashboard-feature-e44/pom.xml
+++ b/org.springsource.ide.eclipse.dashboard-feature-e44/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.dashboard-feature/pom.xml
+++ b/org.springsource.ide.eclipse.dashboard-feature/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/org.springsource.ide.eclipse.dashboard.ui/pom.xml
+++ b/org.springsource.ide.eclipse.dashboard.ui/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springsource.ide.eclipse.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- STS PARENT POM -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springsource.ide.eclipse.commons</groupId>
@@ -13,7 +13,7 @@
 		<connection>scm:git:ssh://git.springsource.com:sts/eclipse-integration-commons.git</connection>
 		<developerConnection>scm:git:ssh://git.springsource.com:sts/eclipse-integration-commons.git</developerConnection>
 		<tag>HEAD</tag>
-		<url>http://git.springsource.com/sts/eclipse-integration-commons</url>
+		<url>https://git.springsource.com/sts/eclipse-integration-commons</url>
 	</scm>
 
 	<modules>
@@ -48,9 +48,9 @@
 	<!-- Common Configuration -->
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
-	<url>http://spring.io/tools</url>
+	<url>https://spring.io/tools</url>
 	<inceptionYear>2007</inceptionYear>
 
 	<prerequisites>
@@ -131,22 +131,22 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/3.7/</url>
+					<url>https://download.eclipse.org/eclipse/updates/3.7/</url>
 				</repository>
 				<repository>
 					<id>indigo</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/indigo/</url>
+					<url>https://download.eclipse.org/releases/indigo/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
+					<url>https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
 				</repository>
 				<repository>
 					<id>javafx</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/efxclipse/updates-released/0.9.0/site</url>
+					<url>https://download.eclipse.org/efxclipse/updates-released/0.9.0/site</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -168,22 +168,22 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.3/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.3/</url>
 				</repository>
 				<repository>
 					<id>juno</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/kepler/</url>
+					<url>https://download.eclipse.org/releases/kepler/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/snapshots</url>
+					<url>https://download.eclipse.org/technology/swtbot/snapshots</url>
 				</repository>
 				<repository>
 					<id>javafx</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/efxclipse/updates-released/0.9.0/site</url>
+					<url>https://download.eclipse.org/efxclipse/updates-released/0.9.0/site</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -205,22 +205,22 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.4/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.4/</url>
 				</repository>
 				<repository>
 					<id>juno</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/luna/</url>
+					<url>https://download.eclipse.org/releases/luna/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/snapshots</url>
+					<url>https://download.eclipse.org/technology/swtbot/snapshots</url>
 				</repository>
 				<repository>
 					<id>javafx</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/efxclipse/updates-released/2.1.0/site/</url>
+					<url>https://download.eclipse.org/efxclipse/updates-released/2.1.0/site/</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -242,22 +242,22 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.5/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.5/</url>
 				</repository>
 				<repository>
 					<id>mars</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/mars/</url>
+					<url>https://download.eclipse.org/releases/mars/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 				<repository>
 					<id>javafx</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/efxclipse/updates-released/2.1.0/site/</url>
+					<url>https://download.eclipse.org/efxclipse/updates-released/2.1.0/site/</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -279,17 +279,17 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.6/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.6/</url>
 				</repository>
 				<repository>
 					<id>neon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/neon/</url>
+					<url>https://download.eclipse.org/releases/neon/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -311,17 +311,17 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.7/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.7/</url>
 				</repository>
 				<repository>
 					<id>oxygen</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/oxygen/</url>
+					<url>https://download.eclipse.org/releases/oxygen/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -343,22 +343,22 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.8/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.8/</url>
 				</repository>
 				<repository>
 					<id>photon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/photon/</url>
+					<url>https://download.eclipse.org/releases/photon/</url>
 				</repository>
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -380,22 +380,22 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.9/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.9/</url>
 				</repository>
 				<repository>
 					<id>photon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/2018-09/</url>
+					<url>https://download.eclipse.org/releases/2018-09/</url>
 				</repository>
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -417,22 +417,22 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.10/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.10/</url>
 				</repository>
 				<repository>
 					<id>photon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/2ß18-12/</url>
+					<url>https://download.eclipse.org/releases/2ß18-12/</url>
 				</repository>
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/S20181031145145/repository</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/S20181031145145/repository</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -462,7 +462,7 @@
 			<activation>
 				<property>
 					<name>java.vendor.url</name>
-					<value>http://www.apple.com/</value>
+					<value>https://www.apple.com/</value>
 				</property>
 			</activation>
 			<properties>
@@ -491,13 +491,13 @@
 		<repository>
 			<id>mylyn</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/mylyn/releases/3.7</url>
+			<url>https://download.eclipse.org/mylyn/releases/3.7</url>
 		</repository>
 
  		<repository>
  			<id>p2-thirdparty-bundles</id>
  			<layout>p2</layout>
- 			<url>http://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo/${misc.p2.repo.version}</url>
+ 			<url>https://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo/${misc.p2.repo.version}</url>
  		</repository>
 
 		<repository>
@@ -506,12 +506,12 @@
 			<!-- More recent needed for HttpComponents. Use of api URIBuilder (used 
 				only by new SpringBoot wizard) If we can replace with something else we can 
 				keep on using this older orbit site -->
-			<!--  <url>http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url> -->
+			<!--  <url>https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url> -->
 			<!--  need recent orbit for receptor client dependencies:  -->
-			<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/</url>
+			<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/</url>
 			<!--  
 			    Remove: repsonsible for this bug? 
-			     <url>http://download.eclipse.org/tools/orbit/downloads/drops/I20131024145017/repository/</url>
+			     <url>https://download.eclipse.org/tools/orbit/downloads/drops/I20131024145017/repository/</url>
 			 -->
 		</repository>
 
@@ -519,7 +519,7 @@
 		<repository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 		<!-- required for commons-cli dependency in c.s.sts.grails.core -->
 		<repository>
@@ -528,7 +528,7 @@
 		</repository>
 		<repository>
 			<id>maven-mirror</id>
-			<url>http://repo.exist.com/maven2</url>
+			<url>https://repo.exist.com/maven2</url>
 		</repository>
 	</repositories>
 
@@ -537,12 +537,12 @@
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 	</pluginRepositories>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://sha256timestamp.ws.symantec.com/sha256/timestamp (400) with 1 occurrences could not be migrated:  
   ([https](https://sha256timestamp.ws.symantec.com/sha256/timestamp) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://git.springsource.com/sts/eclipse-integration-commons (UnknownHostException) with 1 occurrences migrated to:  
  https://git.springsource.com/sts/eclipse-integration-commons ([https](https://git.springsource.com/sts/eclipse-integration-commons) result UnknownHostException).
* http://repo.exist.com/maven2 (UnknownHostException) with 1 occurrences migrated to:  
  https://repo.exist.com/maven2 ([https](https://repo.exist.com/maven2) result UnknownHostException).
* http://download.eclipse.org/releases/2 (404) with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/2 ([https](https://download.eclipse.org/releases/2) result 404).
* http://download.eclipse.org/tools/orbit/downloads/drops/I20131024145017/repository/ (404) with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/I20131024145017/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/I20131024145017/repository/) result 404).
* http://repository.springsource.com/maven/bundles/release (404) with 2 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo/ with 1 occurrences migrated to:  
  https://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo/ ([https](https://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo/) result 200).
* http://download.eclipse.org/eclipse/updates/3.7/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/3.7/ ([https](https://download.eclipse.org/eclipse/updates/3.7/) result 200).
* http://download.eclipse.org/eclipse/updates/4.10/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.10/ ([https](https://download.eclipse.org/eclipse/updates/4.10/) result 200).
* http://download.eclipse.org/eclipse/updates/4.3/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.3/ ([https](https://download.eclipse.org/eclipse/updates/4.3/) result 200).
* http://download.eclipse.org/eclipse/updates/4.4/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.4/ ([https](https://download.eclipse.org/eclipse/updates/4.4/) result 200).
* http://download.eclipse.org/eclipse/updates/4.5/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.5/ ([https](https://download.eclipse.org/eclipse/updates/4.5/) result 200).
* http://download.eclipse.org/eclipse/updates/4.6/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.6/ ([https](https://download.eclipse.org/eclipse/updates/4.6/) result 200).
* http://download.eclipse.org/eclipse/updates/4.7/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.7/ ([https](https://download.eclipse.org/eclipse/updates/4.7/) result 200).
* http://download.eclipse.org/eclipse/updates/4.8/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.8/ ([https](https://download.eclipse.org/eclipse/updates/4.8/) result 200).
* http://download.eclipse.org/eclipse/updates/4.9/ with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.9/ ([https](https://download.eclipse.org/eclipse/updates/4.9/) result 200).
* http://download.eclipse.org/efxclipse/updates-released/2.1.0/site/ with 2 occurrences migrated to:  
  https://download.eclipse.org/efxclipse/updates-released/2.1.0/site/ ([https](https://download.eclipse.org/efxclipse/updates-released/2.1.0/site/) result 200).
* http://download.eclipse.org/releases/2018-09/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/2018-09/ ([https](https://download.eclipse.org/releases/2018-09/) result 200).
* http://download.eclipse.org/releases/indigo/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/indigo/ ([https](https://download.eclipse.org/releases/indigo/) result 200).
* http://download.eclipse.org/releases/kepler/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/kepler/ ([https](https://download.eclipse.org/releases/kepler/) result 200).
* http://download.eclipse.org/releases/luna/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/luna/ ([https](https://download.eclipse.org/releases/luna/) result 200).
* http://download.eclipse.org/releases/mars/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/mars/ ([https](https://download.eclipse.org/releases/mars/) result 200).
* http://download.eclipse.org/releases/neon/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/neon/ ([https](https://download.eclipse.org/releases/neon/) result 200).
* http://download.eclipse.org/releases/oxygen/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/oxygen/ ([https](https://download.eclipse.org/releases/oxygen/) result 200).
* http://download.eclipse.org/releases/photon/ with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/photon/ ([https](https://download.eclipse.org/releases/photon/) result 200).
* http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/ with 1 occurrences migrated to:  
  https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/ ([https](https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/) result 200).
* http://download.eclipse.org/technology/swtbot/releases/latest/ with 6 occurrences migrated to:  
  https://download.eclipse.org/technology/swtbot/releases/latest/ ([https](https://download.eclipse.org/technology/swtbot/releases/latest/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20150519210750/repository/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/ with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/) result 200).
* http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://spring.io/tools with 1 occurrences migrated to:  
  https://spring.io/tools ([https](https://spring.io/tools) result 200).
* http://www.apple.com/ with 1 occurrences migrated to:  
  https://www.apple.com/ ([https](https://www.apple.com/) result 200).
* http://download.eclipse.org/efxclipse/updates-released/0.9.0/site with 2 occurrences migrated to:  
  https://download.eclipse.org/efxclipse/updates-released/0.9.0/site ([https](https://download.eclipse.org/efxclipse/updates-released/0.9.0/site) result 301).
* http://download.eclipse.org/mylyn/releases/3.7 with 1 occurrences migrated to:  
  https://download.eclipse.org/mylyn/releases/3.7 ([https](https://download.eclipse.org/mylyn/releases/3.7) result 301).
* http://download.eclipse.org/technology/swtbot/snapshots with 2 occurrences migrated to:  
  https://download.eclipse.org/technology/swtbot/snapshots ([https](https://download.eclipse.org/technology/swtbot/snapshots) result 301).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository) result 301).
* http://download.eclipse.org/tools/orbit/downloads/drops/S20181031145145/repository with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/S20181031145145/repository ([https](https://download.eclipse.org/tools/orbit/downloads/drops/S20181031145145/repository) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 23 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://maven.springframework.org/release with 1 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 46 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 23 occurrences